### PR TITLE
changing pytorch image family name to the latest one.

### DIFF
--- a/scripts/create_instance.sh
+++ b/scripts/create_instance.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-export IMAGE_FAMILY="pytorch-1-0-cu92-experimental"
+export IMAGE_FAMILY="pytorch-latest-gpu"
 export ZONE="northamerica-northeast1-b"
 export INSTANCE_NAME="fastai-instance"
 export INSTANCE_TYPE="n1-highmem-8"


### PR DESCRIPTION
PyTorch 1.0 images are no longer experimental.